### PR TITLE
Hotfix: 게시글 조회 시 Total 개수 올바르지 않은 것 수정 [#36]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kormelon-blog-back-v3",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "kormelon blog server",
   "main": "./dist/app.js",
   "scripts": {

--- a/src/services/post/post.service.ts
+++ b/src/services/post/post.service.ts
@@ -36,7 +36,7 @@ class PostService extends Repository<Post> {
     keyword: string,
     subCategoryId?: number
   ) {
-    const posts = await this.find({
+    const [posts, total] = await this.findAndCount({
       where: {
         isPrivate: false,
         title: Like(`%${keyword}%`),
@@ -50,7 +50,7 @@ class PostService extends Repository<Post> {
     });
 
     return {
-      total: posts.length,
+      total,
       posts,
     };
   }


### PR DESCRIPTION
## Fixes <!-- 고쳐진 오류들 -->

- 게시글 전체 조회 시 totalCount 가지고 오도록 수정함.

## Refs <!-- 연관된 이슈나 PR 주소들 -->

resolve #36 